### PR TITLE
Update views.py to be compatible with the latest stable version of flask

### DIFF
--- a/flaskcode/views.py
+++ b/flaskcode/views.py
@@ -18,7 +18,7 @@ def resource_data(file_path):
     file_path = os.path.join(g.flaskcode_resource_basepath, file_path)
     if not (os.path.exists(file_path) and os.path.isfile(file_path)):
         abort(404)
-    response = send_file(file_path, mimetype='text/plain', cache_timeout=0)
+    response = send_file(file_path, mimetype='text/plain', max_age=0)
     mimetype, encoding = mimetypes.guess_type(file_path, False)
     if mimetype:
         response.headers.set('X-File-Mimetype', mimetype)


### PR DESCRIPTION
When sending the file to the browser, it has to be new, it is currently achieved by this:

```py
response = send_file(file_path, mimetype='text/plain', cache_timeout=0)
```

The latest **stable version** of Flask now, uses `max_age` . People can fix this themselves locally but its an inconvinience.

Hopefully this gets merged :)